### PR TITLE
[wip] use new pouchdb wrappers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,10 @@
       "version": "1.1.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "pouchdb-wrappers": "github:neighbourhoodie/pouchdb-wrappers#mergemaster"
+        "pouchdb-wrappers": "file:../pouchdb-wrappers"
       },
       "devDependencies": {
+        "babelify": "^10.0.0",
         "dependency-check": "^4.1.0",
         "envify": "^4.1.0",
         "mocha": "^8.3.2",
@@ -22,6 +23,20 @@
         "standard": "^16.0.3",
         "uglify-js": "^3.13.10",
         "uglifyjs": "^2.4.11"
+      }
+    },
+    "../pouchdb-wrappers": {
+      "version": "5.0.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "babel-plugin-istanbul": "^6.0.0",
+        "babelify": "^10.0.0",
+        "dependency-check": "^4.1.0",
+        "mocha": "^9.0.2",
+        "mochify": "^8.1.0",
+        "nyc": "^15.1.0",
+        "pouchdb": "^7.2.2",
+        "standard": "^16.0.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -838,6 +853,18 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/babelify": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/babelify/-/babelify-10.0.0.tgz",
+      "integrity": "sha512-X40FaxyH7t3X+JFAKvb1H9wooWKLRCi8pg3m8poqtdZaIng+bjzp9RvKQCvRjF9isHiPkXspbbXT/zwXLtwgwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -6198,10 +6225,8 @@
       }
     },
     "node_modules/pouchdb-wrappers": {
-      "resolved": "git+ssh://git@github.com/neighbourhoodie/pouchdb-wrappers.git#f67e2e74f400afaddf8ab886b4754d2c564037e9",
-      "dependencies": {
-        "promise-nodify": "^1.0.1"
-      }
+      "resolved": "../pouchdb-wrappers",
+      "link": true
     },
     "node_modules/pouchdb/node_modules/inherits": {
       "version": "2.0.4",
@@ -6298,11 +6323,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/promise-nodify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/promise-nodify/-/promise-nodify-1.0.2.tgz",
-      "integrity": "sha1-DQ+xQ8M0ALAGG0flgSV1VwR9TFo="
     },
     "node_modules/prop-types": {
       "version": "15.7.2",
@@ -9221,6 +9241,13 @@
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.4.tgz",
       "integrity": "sha512-SA5mXJWrId1TaQjfxUYghbqQ/hYioKmLJvPJyDuYRtXXenFNMjj4hSSt1Cf1xsuXSXrtxrVC5Ot4eU6cOtBDdA==",
       "dev": true
+    },
+    "babelify": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/babelify/-/babelify-10.0.0.tgz",
+      "integrity": "sha512-X40FaxyH7t3X+JFAKvb1H9wooWKLRCi8pg3m8poqtdZaIng+bjzp9RvKQCvRjF9isHiPkXspbbXT/zwXLtwgwg==",
+      "dev": true,
+      "requires": {}
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -13765,10 +13792,16 @@
       }
     },
     "pouchdb-wrappers": {
-      "version": "git+ssh://git@github.com/neighbourhoodie/pouchdb-wrappers.git#f67e2e74f400afaddf8ab886b4754d2c564037e9",
-      "from": "pouchdb-wrappers@https://github.com/neighbourhoodie/pouchdb-wrappers.git#mergemaster",
+      "version": "file:../pouchdb-wrappers",
       "requires": {
-        "promise-nodify": "^1.0.1"
+        "babel-plugin-istanbul": "^6.0.0",
+        "babelify": "^10.0.0",
+        "dependency-check": "^4.1.0",
+        "mocha": "^9.0.2",
+        "mochify": "^8.1.0",
+        "nyc": "^15.1.0",
+        "pouchdb": "^7.2.2",
+        "standard": "^16.0.3"
       }
     },
     "prelude-ls": {
@@ -13797,11 +13830,6 @@
       "requires": {
         "fromentries": "^1.2.0"
       }
-    },
-    "promise-nodify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/promise-nodify/-/promise-nodify-1.0.2.tgz",
-      "integrity": "sha1-DQ+xQ8M0ALAGG0flgSV1VwR9TFo="
     },
     "prop-types": {
       "version": "15.7.2",

--- a/package.json
+++ b/package.json
@@ -32,9 +32,10 @@
     "coverage": "nyc npm test"
   },
   "dependencies": {
-    "pouchdb-wrappers": "github:neighbourhoodie/pouchdb-wrappers#mergemaster"
+    "pouchdb-wrappers": "file:../pouchdb-wrappers"
   },
   "devDependencies": {
+    "babelify": "^10.0.0",
     "dependency-check": "^4.1.0",
     "envify": "^4.1.0",
     "mocha": "^8.3.2",

--- a/test.js
+++ b/test.js
@@ -301,7 +301,8 @@ function tests (dbName, dbType) {
     it('transforms on bulkGet()', async function () {
       db.transform({
         outgoing: async function (doc) {
-          return { ...doc, foo: 'baz' }
+          doc.foo = 'baz'
+          return doc
         }
       })
 


### PR DESCRIPTION
This PR demonstrates how transform-pouch will work with the [refactored pouchdb-wrappers](https://github.com/neighbourhoodie/pouchdb-wrappers/pull/2). This uses a directory-relative import and so requires a little extra instrumentation to run yourself. As a result, this PR is presented primarily to demonstrate how using pouchdb-wrappers will change due to the refactor.

Once pouchdb-wrappers' new version has been published, this PR can update its dependency and be considered for merging.